### PR TITLE
Fix admin setup user level check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { TreePine, Heart, Database, Plus, LogIn, UserPlus, LogOut, User, Shield, Clock, XCircle, Calendar, Image, FileText } from 'lucide-react';
+import { TreePine, Heart, Database, Plus, LogOut, User, Shield, Clock, XCircle, Calendar, Image, FileText } from 'lucide-react';
 import ArabicFamilyTreeDemo from './components/ArabicFamilyTreeDemo';
 import DataEntryManager from './components/DataEntry/DataEntryManager';
 import FamilyTree from './components/FamilyTree';
@@ -9,7 +9,6 @@ import AuthForm from './components/AuthForm';
 import AdminPanel from './components/AdminPanel';
 import NewsPage from './components/NewsPage';
 import { supabase } from './services/arabicFamilyService';
-import ResponsiveHeader from './components/responsive/ResponsiveHeader';
 import ResponsiveFooter from './components/responsive/ResponsiveFooter';
 import ResponsiveContainer from './components/responsive/ResponsiveContainer';
 import ResponsiveFlex from './components/responsive/ResponsiveFlex';

--- a/src/components/AddMemberForm.tsx
+++ b/src/components/AddMemberForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useForm, watch } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { Plus, User, Calendar, Phone, FileText, Heart, Skull } from 'lucide-react';
 import { FamilyMember, FamilyMemberFormData } from '../types/FamilyMember';
 import { familyService } from '../services/supabase';

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -134,7 +134,7 @@ export default function AuthForm({ mode, onSuccess, onCancel, onSwitchMode }: Au
             console.error('Error creating profile:', insertError);
             throw new Error('فشل في إنشاء ملف المدير. يرجى التحقق من صلاحيات قاعدة البيانات.');
           }
-        } else if (profile.user_level !== 'admin' || profile.approval_status !== 'approved') {
+        } else if (profile.role_id !== adminRoleData.id || profile.approval_status !== 'approved') {
           // Update to admin
           const { error: updateError } = await supabase
             .from('user_profiles')


### PR DESCRIPTION
## Summary
- fix admin setup to check role_id instead of removed user_level column
- clean up imports in App.tsx

## Testing
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68841f3768988326a11b6b5f3dc739b7